### PR TITLE
Improved error handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,7 @@ target_link_libraries(${COOL_LIBRARY_NAME} ${COOL_LINK_LIBRARIES})
 # --- Tests
 set (TESTS
    runner
+   on_exception
 )
 
 # --- Doxygen documentation

--- a/include/cool/entrails/traits.h
+++ b/include/cool/entrails/traits.h
@@ -1,0 +1,72 @@
+/* Copyright (c) 2016 Digiverse d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. The
+ * license should be included in the source distribution of the Software;
+ * if not, you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * The above copyright notice and licensing terms shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#if !defined(COOL_TRAITS_H_HEADER_GUARD)
+#define COOL_TRAITS_H_HEADER_GUARD
+
+namespace cool { namespace gcd { namespace traits {
+
+template <typename...>
+struct arg_type;
+
+template <typename Arg>
+struct arg_type<Arg>
+{
+  typedef Arg first_arg;
+  typedef std::true_type has_one_arg;
+};
+
+template <typename Arg, typename... Args>
+struct arg_type<Arg, Args...>
+{
+  typedef Arg first_arg;
+  typedef std::false_type has_one_arg;
+};
+
+template <>
+struct arg_type<>
+{
+  typedef void first_arg;
+  typedef std::false_type has_one_arg;
+};
+
+
+template <typename L>
+struct info : info<decltype(&L::operator())> { };
+
+template <typename Class, typename R, typename... Args>
+struct info<R(Class::*)(Args...) const>
+{
+  typedef R result;
+  typedef typename arg_type<Args...>::first_arg first_arg;
+  typedef typename arg_type<Args...>::has_one_arg has_one_arg;
+};
+template <typename Class, typename R, typename... Args>
+struct info<R(Class::*)(Args...)>
+{
+  typedef R result;
+  typedef typename arg_type<Args...>::first_arg first_arg;
+  typedef typename arg_type<Args...>::has_one_arg has_one_arg;
+};
+
+}}}
+
+#endif

--- a/include/cool/gcd_task.h
+++ b/include/cool/gcd_task.h
@@ -588,6 +588,49 @@ template <typename Result> class task
   then(const std::weak_ptr<runner>& runner_, const error_handler_t &err_, Function &&func_, Args&&... args_)
 #endif
   {
+    if (m_info == nullptr)
+      throw cool::exception::illegal_state("this task object is in undefined state");
+
+    auto task = then_do(runner_, std::forward<Function>(func_)
+#if !defined(INCORRECT_VARIADIC)
+        , std::forward<Args>(args_)...
+#endif
+    );
+
+    task.m_info->m_eh = err_;
+
+    return task;
+  }
+
+#if defined(INCORRECT_VARIADIC)
+  template <typename Function>
+  task<typename std::result_of<Function(const Result&)>::type>
+  then_do(Function &&func_)
+#else
+  template <typename Function, typename... Args>
+  task<typename std::result_of<Function(const Result&, Args...)>::type>
+  then_do(Function &&func_, Args&&... args_)
+#endif
+  {
+    if (m_info == nullptr)
+      throw cool::exception::illegal_state("this task object is in undefined state");
+    return then_do(m_info->m_runner, std::forward<Function>(func_)
+#if !defined(INCORRECT_VARIADIC)
+        , std::forward<Args>(args_)...
+#endif
+    );
+  }
+
+#if defined(INCORRECT_VARIADIC)
+  template <typename Function>
+  task<typename std::result_of<Function(const Result&)>::type>
+  then_do(const std::weak_ptr<runner>& runner_, Function &&func_)
+#else
+  template <typename Function, typename... Args>
+  task<typename std::result_of<Function(const Result&, Args...)>::type>
+  then_do(const std::weak_ptr<runner>& runner_, Function &&func_, Args&&... args_)
+#endif
+  {
 #if defined(INCORRECT_VARIADIC)
     using subtask_result_t = typename std::result_of<Function(const Result&)>::type;
 #else
@@ -599,7 +642,6 @@ template <typename Result> class task
       throw cool::exception::illegal_state("this task object is in undefined state");
 
     entrails::taskinfo* aux = new entrails::taskinfo(runner_);
-    aux->m_eh = err_;
     m_info->m_next = aux;  // double link
     aux->m_prev = m_info;
 
@@ -874,6 +916,49 @@ template <> class task<void>
   then(const std::weak_ptr<runner>& runner_, const error_handler_t& err_, Function&& func_, Args&&... args_)
 #endif
   {
+    if (m_info == nullptr)
+      throw cool::exception::illegal_state("this task object is in undefined state");
+
+    auto task = then_do(runner_, std::forward<Function>(func_)
+#if !defined(INCORRECT_VARIADIC)
+        , std::forward<Args>(args_)...
+#endif
+    );
+
+    task.m_info->m_eh = err_;
+
+    return task;
+  }
+
+#if defined(INCORRECT_VARIADIC)
+  template <typename Function>
+  task<typename std::result_of<Function()>::type>
+  then_do(Function&& func_)
+#else
+  template <typename Function, typename... Args >
+  task<typename std::result_of<Function(Args...)>::type>
+  then_do(Function&& func_, Args&&... args_)
+#endif
+  {
+    if (m_info == nullptr)
+      throw cool::exception::illegal_state("this task object is in undefined state");
+    return then_do(m_info->m_runner, std::forward<Function>(func_)
+#if !defined(INCORRECT_VARIADIC)
+        , std::forward<Args>(args_)...
+#endif
+    );
+  }
+
+#if defined(INCORRECT_VARIADIC)
+  template <typename Function>
+  task<typename std::result_of<Function()>::type>
+  then_do(const std::weak_ptr<runner>& runner_, Function&& func_)
+#else
+  template <typename Function, typename... Args >
+  task<typename std::result_of<Function(Args...)>::type>
+  then_do(const std::weak_ptr<runner>& runner_, Function&& func_, Args&&... args_)
+#endif
+  {
 #if defined(INCORRECT_VARIADIC)
     using subtask_result_t = typename std::result_of<Function()>::type;
 #else
@@ -885,7 +970,6 @@ template <> class task<void>
       throw cool::exception::illegal_state("this task object is in undefined state");
 
     entrails::taskinfo* aux = new entrails::taskinfo(runner_);
-    aux->m_eh = err_;
     m_info->m_next = aux;  // double link
     aux->m_prev = m_info;
 

--- a/include/cool/gcd_task.h
+++ b/include/cool/gcd_task.h
@@ -463,6 +463,9 @@ template <typename Result> class task
   }
   
   /**
+   * @deprecated
+   * Deprecated in favor of  @ref then_do() and @ref on_exception() or @ref on_any_exception()
+   *
    * Adds a new task to the sequence and returns it.
    *
    * This method template adds a new task to be scheduled for execution upon
@@ -503,8 +506,10 @@ template <typename Result> class task
    *    object.
    *
    * @note Note that since all @ref then() methods invalidate the current and
-   *   return a new task object, the used runner will the last runner explicitly
-   *   passed to any preceding task through @ref then(), or the runner specified
+   *   return a new task object,
+   *   the runner used will be the last runner explicitly
+   *   passed to any preceding task through @ref then(), @ref then_do(),
+   *   @ref on_exception(), @ref on_any_exception() or the runner specified
    *   at @ref factory::create() if none.
    *
    * @warning The error handler @c err is scheduled for the execution
@@ -532,6 +537,9 @@ template <typename Result> class task
   }
 #endif
   /**
+   * @deprecated
+   * Deprecated in favor of  @ref then_do() and @ref on_exception() or @ref on_any_exception()
+   *
    * Adds a new task to the sequence and returns it.
    *
    * This method template adds a new task to be scheduled for execution upon
@@ -602,6 +610,55 @@ template <typename Result> class task
     return task;
   }
 
+  /**
+   * Adds a new task to the sequence and returns it.
+   *
+   * This method template adds a new task to be scheduled for execution upon
+   * the completion of this task. The new task is passed the return value
+   * of this task as its first parameter. The template parameters,
+   * auto-deducted by compiler's template parameter deduction rules that apply
+   * to function templates, are the following:
+   * @tparam Function the function type of the user supplied task (Callable object).
+   *    If the return value type of this task is non-void, the Callable's first
+   *    argument must be @c const @c ResultT&, where ResultT is the type of the
+   *    return value of this task's Callable.
+   * @tparam Args... the template parameter pack of additional arguments passed to
+   *    the user supplied Callable, after the optional first argument.
+   *
+   * The method must be provided with the following parameters:
+   * @param func_ the user supplied Callable to be scheduled for execution upon
+   *    the successful completion of this task.
+   * @param args_ additional arguments to be passed to the user provided
+   *    Callable when it begins the execution. Note that the additional arguments
+   *    are passed after the first argument, if the current task's return value
+   *    is non-void, or as the first, second, etc. argument if it is void.
+   *
+   * @return a new task object, which is to be used from this point on instead
+   *    of the current task object.
+   *
+   * If the current task throws an exception during its execution, the task
+   * library will schedule the first error handler that follows the current task.
+   * Error handlers are specified as parameters in @ref then(), @ref on_exception() and
+   * @ref on_any_exception() methods. If the current task throws an exception then
+   * the user provided Callable @c func_  will not be scheduled.
+   *
+   * If the current task does not
+   * throw an exception, the task library will schedule @c func_ for execution,
+   * optionally passing it a return value of the current task (if non-void).
+   * @c func_ will be scheduled to run on the same @ref cool::gcd::task::runner "runner"
+   * that ran the current task.
+   *
+   * @note This method invalidates the current (@c this) object, and returns
+   *    a new task object. All further operations must be performed on a new
+   *    object.
+   *
+   * @note Note that since all @ref then_do() methods invalidate the current and
+   *   return a new task object,
+   *   the runner used will be the last runner explicitly
+   *   passed to any preceding task through @ref then(), @ref then_do(),
+   *   @ref on_exception(), @ref on_any_exception() or the runner specified
+   *   at @ref factory::create() if none.
+   */
 #if defined(INCORRECT_VARIADIC)
   template <typename Function>
   task<typename std::result_of<Function(const Result&)>::type>
@@ -621,6 +678,49 @@ template <typename Result> class task
     );
   }
 
+  /**
+   * Adds a new task to the sequence and returns it.
+   *
+   * This method template adds a new task to be scheduled for execution upon
+   * the completion of this task. The new task is passed the return value
+   * of this task as its first parameter. The template parameters,
+   * auto-deducted by compiler's template parameter deduction rules that apply
+   * to function templates, are the following:
+   * @tparam Function the function type of the user supplied task (Callable object).
+   *    If the return value type of this task is non-void, the Callable's first
+   *    argument must be @c const @c ResultT&, where ResultT is the type of the
+   *    return value of this task's Callable.
+   * @tparam Args... the template parameter pack of additional arguments passed to
+   *    the user supplied Callable, after the optional first argument.
+   *
+   * The method must be provided with the following parameters:
+   * @param runner_ the @ref cool::gcd::task::runner "runner" to run the @c func_ Callable.
+   * @param func_ the user supplied Callable to be scheduled for execution upon
+   *    the successful completion of this task.
+   * @param args_ additional arguments to be passed to the user provided
+   *    Callable when it begins the execution. Note that the additional arguments
+   *    are passed after the first argument, if the current task's return value
+   *    is non-void, or as the first, second, etc. argument if it is void.
+   *
+   * @return a new task object, which is to be used from this point on instead
+   *    of the current task object.
+   *
+   * If the current task throws an exception during its execution, the task
+   * library will schedule the first error handler that follows the current task.
+   * Error handlers are specified as parameters in @ref then(), @ref on_exception() and
+   * @ref on_any_exception() methods. If the current task throws an exception then
+   * the user provided Callable @c func_  will not be scheduled.
+   *
+   * If the current task does not
+   * throw an exception, the task library will schedule @c func_ for execution,
+   * optionally passing it a return value of the current task (if non-void).
+   * @c func_ will be scheduled to run on the same @ref cool::gcd::task::runner "runner"
+   * that ran the current task.
+   *
+   * @note This method invalidates the current (@c this) object, and returns
+   *    a new task object. All further operations must be performed on a new
+   *    object.
+   */
 #if defined(INCORRECT_VARIADIC)
   template <typename Function>
   task<typename std::result_of<Function(const Result&)>::type>
@@ -665,6 +765,35 @@ template <typename Result> class task
     return task<subtask_result_t>(aux);
   }
 
+  /**
+   * Specifies the error handling task for any type of exception.
+   *
+   * The error handler is a new task that is run only if current task or any of the
+   * previous tasks threw an exception that is not yet handled. The task library will
+   * schedule the first error handler that follows the task that threw an exception
+   * and is able to handle the thrown exception.
+   *
+   * The @c err_ function must accept the thrown exception as parameter and either
+   * handle the exception by returning a result of the same type as current task or
+   * throw the same or another exception. If the @c err_ function throws an exception then
+   * the task library will schedule the next error handler.
+   *
+   * The method must be provided with the following parameters:
+   * @param err_ the user supplied Callable to be scheduled for execution upon exception
+   *    being thrown in any of the preceding tasks.
+   *
+   * @note This method invalidates the current (@c this) object, and returns
+   *    a new task object. All further operations must be performed on a new
+   *    object.
+   *
+   * @note Note that the runner used will be the last runner explicitly
+   *   passed to any preceding task through @ref then(), @ref then_do(),
+   *   @ref on_exception(), @ref on_any_exception() or the runner specified
+   *   at @ref factory::create() if none.
+   *
+   * @note This method, if used, does not finalize the task sequence. It is
+   *   possible to append additional tasks on the task returned by this method.
+   */
   task<Result>
   on_any_exception(std::function<Result(const std::exception_ptr&)>&& err_)
   {
@@ -673,6 +802,31 @@ template <typename Result> class task
     return on_any_exception(m_info->m_runner, std::forward<std::function<Result(const std::exception_ptr&)>>(err_));
   }
 
+  /**
+   * Specifies the error handling task for any type of exception.
+   *
+   * The error handler is a new task that is run only if current task or any of the
+   * previous tasks threw an exception that is not yet handled. The task library will
+   * schedule the first error handler that follows the task that threw an exception
+   * and is able to handle the thrown exception.
+   *
+   * The @c err_ function must accept the thrown exception as parameter and either
+   * handle the exception by returning a result of the same type as current task or
+   * throw the same or another exception. If the @c err_ function throws an exception then
+   * the task library will schedule the next error handler.
+   *
+   * The method must be provided with the following parameters:
+   * @param runner_ the @ref cool::gcd::task::runner "runner" to run the @c err_ Callable.
+   * @param err_ the user supplied Callable to be scheduled for execution upon exception
+   *    being thrown in any of the preceding tasks.
+   *
+   * @note This method invalidates the current (@c this) object, and returns
+   *    a new task object. All further operations must be performed on a new
+   *    object.
+   *
+   * @note This method, if used, does not finalize the task sequence. It is
+   *   possible to append additional tasks on the task returned by this method.
+   */
   task<Result>
   on_any_exception(const std::weak_ptr<runner>& runner_, std::function<Result(const std::exception_ptr&)>&& err_)
   {
@@ -687,6 +841,76 @@ template <typename Result> class task
     return task<Result>(aux);
   }
 
+  /**
+   * Specifies the error handling task handling a particular type of exception
+   *
+   * The error handler is a new task that is run only if current task or any of the
+   * previous tasks threw an exception that is not yet handled. The task library will
+   * schedule the first error handler that follows the task that threw an exception
+   * and is able to handle the thrown exception.
+   * Task returned by this method will be scheduled only if type of exception that
+   * @c err_ function accepts as parameter is the base class of the thrown exception.
+   *
+   * The @c err_ function must handle the exception passed as parameter and either
+   * handle the exception by returning a result of the same type as current task or
+   * throw the same or another exception. If the @c err_ function throws an exception then
+   * the task library will schedule the next error handler that is able to handle it.
+   *
+   * The template parameters,
+   * auto-deducted by compiler's template parameter deduction rules that apply
+   * to function templates, are the following:
+   * @tparam Function the function type of the user supplied function (Callable object).
+   *    If the return value type of this task is non-void, then the Callable's return
+   *    type must be the same as the @c ResultT, where ResultT is the type of the
+   *    return value of this task's Callable.
+   *    the Callable's only parameter must be @c const @c ExceptionT&, where ExceptionT
+   *    is the type of the exception that the Callable @err_ can handle.
+   *
+   * The method must be provided with the following parameters:
+   * @param err_ the user supplied Callable to be scheduled for execution upon exception
+   *    being thrown in any of the preceding tasks.
+   *
+   * This method is provided as utility when only one particular exception type needs to
+   * be handled. For example instead of writing:
+   * @code
+   *   task.on_any_exception([](const std::exception_ptr& p_ex)
+   *   {
+   *     try {
+   *       std::rethrow_exception(p_ex);
+   *     }
+   *     catch (const ExceptionT& ex) {
+   *       ...
+   *       return result;
+   *     }
+   *   };
+   * @endcode
+   *
+   * The same can be achieved by:
+   * @code
+   *   task.on_exception([](const ExceptioT& ex)
+   *   {
+   *     ...
+   *     return result;
+   *   };
+   * @endcode
+   *
+   * @note This method invalidates the current (@c this) object, and returns
+   *    a new task object. All further operations must be performed on a new
+   *    object.
+   *
+   * @note Note that the runner used will be the last runner explicitly
+   *   passed to any preceding task through @ref then(), @ref then_do(),
+   *   @ref on_exception(), @ref on_any_exception() or the runner specified
+   *   at @ref factory::create() if none.
+   *
+   * @note This method, if used, does not finalize the task sequence. It is
+   *   possible to append additional tasks on the task returned by this method.
+   *
+   * @note std::rethrow_exception is executed whenever on_exception task is
+   * examined if it can handle the thrown exception. Therefore use the
+   * @ref on_any_exception with multiple catch clauses when several exception
+   * types are to be handled
+   */
   template <typename Function>
   task<Result>
   on_exception(Function&& err_)
@@ -704,6 +928,13 @@ template <typename Result> class task
     return on_exception(m_info->m_runner, std::forward<Function>(err_));
   }
 
+  /**
+   * Specifies the error handling task handling a particular type of exception
+   *
+   * Same as @ref task<Result>::on_exception(Function&& err_) except that this
+   * method provides additional parameter to specify the
+   * @ref cool::gcd::task::runner "runner" to run the @c err_ Callable.
+   */
   template <typename Function>
   task<Result>
   on_exception(const std::weak_ptr<runner>& runner_, Function&& err_)
@@ -730,19 +961,21 @@ template <typename Result> class task
   }
 
   /**
-   * Specifies the error handling task for the current task.
+   * Specifies the final error handling task.
    *
-   * The error handler for the current task is a new task that is run only
-   * if the current task throws an exception during its execution. The error
-   * handling task is run by the same runner which executed the current
-   * task.
+   * The error handler is a new task that is run only if current task or any of the
+   * previous tasks threw an exception that is not yet handled. The task library will
+   * schedule the first error handler that follows the task that threw an exception
+   * and is able to handle the thrown exception.
    *
    * @note This method invalidates the current (@c this) object, and returns
    *    a new task object. All further operations must be performed on a new
    *    object.
    * @note Note that since all @ref then() methods invalidate the current and
-   *   return a new task object, the used runner will the last runner explicitly
-   *   passed to any preceding task through @ref then(), or the runner specified
+   *   return a new task object,
+   *   the runner used will be the last runner explicitly
+   *   passed to any preceding task through @ref then(), @ref then_do(),
+   *   @ref on_exception(), @ref on_any_exception() or the runner specified
    *   at @ref factory::create() if none.
    *
    * @note This method, if used, finalizes the task sequence. Althought it is
@@ -757,11 +990,12 @@ template <typename Result> class task
   }
   
   /**
-   * Specifies the error handling task for the current task.
+   * Specifies the final error handling task.
    *
-   * The error handler for the current task is a new task that is run only
-   * if the current task throws an exception during its execution. The error
-   * handling task is run by the runner specified by @c runner_ parameter.
+   * The error handler is a new task that is run only if current task or any of the
+   * previous tasks threw an exception that is not yet handled. The task library will
+   * schedule the first error handler that follows the task that threw an exception
+   * and is able to handle the thrown exception.
    *
    * @note This method invalidates the current (@c this) object, and returns
    *    a new task object. All further operations must be performed on a new

--- a/test/test_on_exception.cpp
+++ b/test/test_on_exception.cpp
@@ -1,0 +1,163 @@
+/* Copyright (c) 2016 Digiverse d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. The
+ * license should be included in the source distribution of the Software;
+ * if not, you may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * The above copyright notice and licensing terms shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+#include <chrono>
+#include <thread>
+
+#include <gtest/gtest.h>
+#include "cool/gcd_task.h"
+
+using namespace cool::basis;
+
+
+// Test for backward compatibility. Tasks with error handlers break execution chain
+TEST(on_exception, error_handling_tasks)
+{
+  auto&& r = std::make_shared<cool::gcd::task::runner>();
+
+  std::mutex mutexWait;
+  std::condition_variable cvWait;
+  bool ok = false;
+
+  auto&& task = cool::gcd::task::factory::create(r,
+      [](){
+        std::cout << "task 1 throwing" << std::endl;
+        throw std::range_error("TestError");
+      }).
+  then(
+      [&mutexWait, &cvWait, &ok](const std::exception_ptr& ex){
+        std::cout << "expected" << std::endl;
+        std::unique_lock<std::mutex> l(mutexWait);
+        ok = true;
+        cvWait.notify_one();
+      },
+      [](){
+        FAIL() << "Should not get here";
+      }).
+  then(
+      [](const std::exception_ptr& ex){
+        FAIL() << "Should not get here";
+      },
+      [](){
+        FAIL() << "Should not get here";
+      });
+
+  task.run();
+
+  std::unique_lock<std::mutex> l(mutexWait);
+  cvWait.wait(l);
+
+  ASSERT_TRUE(ok);
+}
+
+TEST(on_exception, on_any_exception_void)
+{
+  auto&& r = std::make_shared<cool::gcd::task::runner>();
+
+  std::mutex mutexWait;
+  std::condition_variable cvWait;
+  bool ok = false;
+
+  auto&& task = cool::gcd::task::factory::create(r,
+      [](){
+        std::cout << "task 1 throwing" << std::endl;
+        throw std::range_error("TestError");
+      }).
+//  then(
+//      [](){
+//        std::cout << "You should not see this. This task is skipped." << std::endl;
+//      }).
+  on_any_exception(r,
+      [](const std::exception_ptr& ex_ptr){
+        try {
+          std::rethrow_exception(ex_ptr);
+        }
+        catch (const std::range_error& ex) {
+          std::cout << __LINE__ << " handling: " << ex.what() << std::endl;
+        }
+      }).
+  then(
+      [](const std::exception_ptr& ex){
+        FAIL() << "Should not get here";
+      },
+      [&mutexWait, &cvWait, &ok](){
+        std::unique_lock<std::mutex> l(mutexWait);
+        ok = true;
+        cvWait.notify_one();
+      });
+
+  task.run();
+
+  std::unique_lock<std::mutex> l(mutexWait);
+  cvWait.wait(l);
+
+  ASSERT_TRUE(ok);
+}
+
+TEST(on_exception, on_any_exception_typed)
+{
+  auto&& r = std::make_shared<cool::gcd::task::runner>();
+
+  std::mutex mutexWait;
+  std::condition_variable cvWait;
+  std::string result("");
+
+  auto&& task = cool::gcd::task::factory::create(r,
+      []()->std::string{
+        std::cout << "task 1 throwing" << std::endl;
+        throw std::range_error("TestError");
+      }).
+//  then(
+//      [](){
+//        std::cout << "You should not see this. This task is skipped." << std::endl;
+//      }).
+  on_any_exception(r,
+      [](const std::exception_ptr& ex_ptr)->std::string{
+        try {
+          std::rethrow_exception(ex_ptr);
+        }
+        catch (const std::range_error& ex) {
+          std::cout << __LINE__ << " handling: " << ex.what() << std::endl;
+          return "Correct";
+        }
+      }).
+  then(
+      [](const std::exception_ptr& ex){
+        FAIL() << "Should not get here";
+      },
+      [&mutexWait, &cvWait, &result](const std::string& r){
+        std::unique_lock<std::mutex> l(mutexWait);
+        result = r;
+        cvWait.notify_one();
+      });
+
+  task.run();
+
+  std::unique_lock<std::mutex> l(mutexWait);
+  cvWait.wait(l);
+
+  ASSERT_EQ("Correct", result);
+}
+
+
+
+
+

--- a/test/test_on_exception.cpp
+++ b/test/test_on_exception.cpp
@@ -50,14 +50,14 @@ TEST(on_exception, error_handling_tasks)
         cvWait.notify_one();
       },
       [](){
-        FAIL() << "Should not get here";
+        FAIL() << "Should not get here. Error handler should be called.";
       }).
   then(
       [](const std::exception_ptr& ex){
-        FAIL() << "Should not get here";
+        FAIL() << "Should not get here. Error handler above breaks the chain";
       },
       [](){
-        FAIL() << "Should not get here";
+        FAIL() << "Should not get here. Error handler above breaks the chain";
       });
 
   task.run();
@@ -155,6 +155,281 @@ TEST(on_exception, on_any_exception_typed)
   cvWait.wait(l);
 
   ASSERT_EQ("Correct", result);
+}
+
+// Test if various variants compile and are executed
+TEST(on_exception, on_any_exception_variants)
+{
+  auto&& r = std::make_shared<cool::gcd::task::runner>();
+
+  std::mutex mutexWait;
+  std::condition_variable cvWait;
+  int n = 0;
+
+  // no error handler handles the exception so all are executed
+  auto&& task = cool::gcd::task::factory::create(r,
+      [](){ throw std::range_error("TestError"); })
+  .on_any_exception(r,
+      [&n](const std::exception_ptr& ex_ptr){ ++n; std::rethrow_exception(ex_ptr); })
+  .on_any_exception( /* no runner */
+      [&n](const std::exception_ptr& ex_ptr){ ++n; std::rethrow_exception(ex_ptr); })
+  .then(
+      [&mutexWait, &cvWait, &n](const std::exception_ptr&){
+        std::unique_lock<std::mutex> l(mutexWait);
+        ++n;
+        cvWait.notify_one();
+      },
+      [](){
+        FAIL() << "Should not get here";
+      });
+
+  task.run();
+
+  std::unique_lock<std::mutex> l(mutexWait);
+  cvWait.wait(l);
+
+  ASSERT_EQ(3, n);
+}
+
+// Test for on_exception handling concrete type of exception.
+TEST(on_exception, on_exception_void)
+{
+  auto&& r = std::make_shared<cool::gcd::task::runner>();
+
+  std::mutex mutexWait;
+  std::condition_variable cvWait;
+  bool ok = false;
+
+  auto&& task = cool::gcd::task::factory::create(r,
+      [](){
+        std::cout << "task 1 throwing" << std::endl;
+        throw std::range_error("TestError");
+      }).
+//  then(
+//      [](){
+//        std::cout << "You should not see this. This task is skipped." << std::endl;
+//      }).
+  on_exception(r,
+      [](const std::range_error& ex){
+        std::cout << __LINE__ << " handling: " << ex.what() << std::endl;
+      }).
+  then(
+      [](const std::exception_ptr& ex){
+        FAIL() << "Should not get here";
+      },
+      [&mutexWait, &cvWait, &ok](){
+        std::unique_lock<std::mutex> l(mutexWait);
+        ok = true;
+        cvWait.notify_one();
+      });
+
+  task.run();
+
+  std::unique_lock<std::mutex> l(mutexWait);
+  cvWait.wait(l);
+
+  ASSERT_TRUE(ok);
+}
+
+// Test for on_exception handling concrete type of exception.
+TEST(on_exception, on_exception_typed)
+{
+  auto&& r = std::make_shared<cool::gcd::task::runner>();
+
+  std::mutex mutexWait;
+  std::condition_variable cvWait;
+  std::string result("");
+
+  auto&& task = cool::gcd::task::factory::create(r,
+      []()->std::string{
+        std::cout << "task 1 throwing" << std::endl;
+        throw std::range_error("TestError");
+      }).
+//  then(
+//      [](){
+//        std::cout << "You should not see this. This task is skipped." << std::endl;
+//      }).
+  on_exception(r,
+      [](const std::range_error& ex)->std::string{
+        std::cout << __LINE__ << " handling: " << ex.what() << std::endl;
+        return "Correct";
+      }).
+  then(
+      [](const std::exception_ptr& ex){
+        FAIL() << "Should not get here";
+      },
+      [&mutexWait, &cvWait, &result](const std::string& r){
+        std::unique_lock<std::mutex> l(mutexWait);
+        result = r;
+        cvWait.notify_one();
+      });
+
+  task.run();
+
+  std::unique_lock<std::mutex> l(mutexWait);
+  cvWait.wait(l);
+
+  ASSERT_EQ("Correct", result);
+}
+
+// Test if various variants compile and are executed
+TEST(on_exception, on_exception_variants)
+{
+  auto&& r = std::make_shared<cool::gcd::task::runner>();
+
+  std::mutex mutexWait;
+  std::condition_variable cvWait;
+  int n = 0;
+
+  // no error handler takes the right exception type so none are executed
+  auto&& task = cool::gcd::task::factory::create(r,
+      [](){
+        std::cout << "task 1 throwing" << std::endl;
+        throw std::overflow_error("TestError");
+      })
+  .on_exception(r, // int as exception is regular code
+      [&n](int ex_ptr){ ++n; })
+  .on_exception( // int as exception is regular code
+      [&n](int ex_ptr){ ++n; })
+  .on_exception(r,
+      [&n](const std::range_error& ex){ ++n; })
+  .on_exception( // no runner
+      [&n](const std::range_error& ex){ ++n; })
+  .then(
+      [&mutexWait, &cvWait, &n](const std::exception_ptr&){
+        std::unique_lock<std::mutex> l(mutexWait);
+        ++n;
+        cvWait.notify_one();
+      },
+      [](){
+        FAIL() << "Should not get here";
+      });
+
+  task.run();
+
+  std::unique_lock<std::mutex> l(mutexWait);
+  cvWait.wait(l);
+
+  ASSERT_EQ(1, n);
+}
+
+// Test that irregular code doesn't compile
+TEST(on_exception, on_exception_no_compile)
+{
+  auto&& r = std::make_shared<cool::gcd::task::runner>();
+
+  auto&& void_task = cool::gcd::task::factory::create(r,
+      [](){ })
+#if defined(COMPILE_TESTS)
+  .on_exception(r,
+      // must have 1 parameter
+      [](const std::exception_ptr& ex_ptr, const int& i){ })
+  .on_exception(
+      // must have 1 parameter
+      [](const std::exception_ptr& ex_ptr, const int& i){ })
+  .on_exception(r,
+      // must have 1 parameter
+      [](){ })
+  .on_exception(
+      // must have 1 parameter
+      [](){ })
+  .on_exception(r,
+      // return type must match
+      [](const std::exception_ptr& ex_ptr){ return 0; })
+  .on_exception(
+      // return type must match
+      [](const std::exception_ptr& ex_ptr){ return 0; })
+#endif
+  ;
+
+  auto&& typed_task = cool::gcd::task::factory::create(r,
+      []()->int{ return 57; })
+#if defined(COMPILE_TESTS)
+  .on_exception(r,
+      // must have 1 parameter
+      [](const std::exception_ptr& ex_ptr, const int& i){ return 0; })
+  .on_exception(
+      // must have 1 parameter
+      [](const std::exception_ptr& ex_ptr, const int& i){ return 0; })
+  .on_exception(r,
+      // must have 1 parameter
+      [](){ return 0; })
+  .on_exception(
+      // must have 1 parameter
+      [](){ return 0; })
+  .on_exception(r,
+      // return type must match
+      [](const std::exception_ptr& ex_ptr){ return ""; })
+  .on_exception(
+      // return type must match
+      [](const std::exception_ptr& ex_ptr){ return ""; })
+#endif
+  ;
+}
+
+// Testing variants of tasks in one chain
+TEST(on_exception, task_chain)
+{
+  auto&& r = std::make_shared<cool::gcd::task::runner>();
+
+  std::mutex mutexWait;
+  std::condition_variable cvWait;
+  int result = 0;
+
+  cool::gcd::task::factory::create(r,
+      []()->int{
+        //throw std::runtime_error("Test error");
+        throw std::range_error("Can't do.");
+      }).
+//  then(
+//      [](std::string result)->std::string{
+//        std::cout << "You should not see this. This task is skipped." << std::endl;
+//        return "Oops" + result;
+//      }).
+  on_exception(r,
+      [](const std::underflow_error& ex) {
+        std::cout << "Should not get here. Incorrect exception type";
+        return -__LINE__;
+      }).
+  on_exception(r,
+      [](const std::range_error& ex) {
+        std::cout << __LINE__ << " handling: " << ex.what() << std::endl;
+        return 57;
+      }).
+  on_exception(r,
+      [](const std::runtime_error& ex) {
+        std::cout << "Should not get here.";
+        return -__LINE__;
+      }).
+  on_any_exception(r,
+      [](const std::exception_ptr& ex_ptr) {
+        std::cout << "Should not get here.";
+        return -__LINE__;
+      }).
+//  then(
+//      [](const std::string& result){
+//        std::cout << "Result: " << result << std::endl;
+//        return 0;
+//      }).
+  then(
+      [](const std::exception_ptr& ex){
+        FAIL() << "Should not get here";
+      },
+      [&mutexWait, &cvWait, &result](const int& r){
+        std::unique_lock<std::mutex> l(mutexWait);
+        result = r;
+        cvWait.notify_one();
+      }).
+  finally(
+      [](const std::exception_ptr&){
+        std::cerr << "Bad things happened" << std::endl;
+      }).
+  run();
+
+  std::unique_lock<std::mutex> l(mutexWait);
+  cvWait.wait(l);
+
+  ASSERT_EQ(57, result);
 }
 
 


### PR DESCRIPTION
Issue:
When any task in a sequence of tasks built with task<>.then method threw an exception then that exception had to be caught in the next task in the sequence. It was not possible to handle the exception is such a way to continue the sequence of tasks after exception was handled.

Added methods that enable implementing sequence of tasks that is similar to using try/catch statements.
Added on_exception and on_any_exception methods that return tasks that can handle exception by returning a Result, so that task sequence can continue to execute.
Also added then_do variants methods. Tasks created with then_do methods only get executed if a valid result is returned by the previous task.
